### PR TITLE
Get enough precision for calculating the width of the movie.

### DIFF
--- a/src/scripts/terminal.js
+++ b/src/scripts/terminal.js
@@ -70,22 +70,22 @@
     },
 
     calculateCharDimensions: function() {
-      var $tmpChild = $('<span class="font-sample"><span class="line"><span class="char">MMMMMMMMMM</span></span></span>');
+      var $tmpChild = $('<span class="font-sample"><span class="line"><span class="char">MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM</span></span></span>');
       this.getDOMNode().appendChild($tmpChild[0]);
       var $span = $tmpChild.find('.char');
 
       var charDimensions = {};
 
       $tmpChild.addClass('font-small');
-      charDimensions.small = { width: $span.width() / 10, height: $tmpChild.height() };
+      charDimensions.small = { width: $span.width() / 200, height: $tmpChild.height() };
 
       $tmpChild.removeClass('font-small');
       $tmpChild.addClass('font-medium');
-      charDimensions.medium = { width: $span.width() / 10, height: $tmpChild.height() };
+      charDimensions.medium = { width: $span.width() / 200, height: $tmpChild.height() };
 
       $tmpChild.removeClass('font-medium');
       $tmpChild.addClass('font-big');
-      charDimensions.big = { width: $span.width() / 10, height: $tmpChild.height() };
+      charDimensions.big = { width: $span.width() / 200, height: $tmpChild.height() };
 
       $tmpChild.remove();
 


### PR DESCRIPTION
The solution is to use more `M` characters to get a more accurate
measurement of its width. Currently 200 `M` characters are used in
stead of 10.

See: asciinema/asciinema.org#169
