### PR TITLE
Updated the movie width to `Math.ceil(x)`.

### DIFF
--- a/src/scripts/terminal.js
+++ b/src/scripts/terminal.js
@@ -38,8 +38,8 @@
     style: function() {
       if (this.state.charDimensions) {
         var dimensions = this.state.charDimensions[this.props.fontSize];
-        var width  = this.props.width  * dimensions.width  + 'px';
-        var height = this.props.height * dimensions.height + 'px';
+        var width  = Math.ceil(this.props.width  * dimensions.width)  + 'px';
+        var height = Math.ceil(this.props.height * dimensions.height) + 'px';
         return { width: width, height: height };
       } else {
         return {};


### PR DESCRIPTION
This should fix the off-by-one error in some browsers.

See: #2 and asciinema/asciinema.org#169
