### PR TITLE
Add a `package.json` file to install the JS and CSS files with yarn

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ pom.xml.asc
 /.repl
 .nrepl-history
 node_modules/
+*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ pom.xml.asc
 /out
 /.repl
 .nrepl-history
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "asciinema-player",
+  "title": "asciinema player",
+  "description": "Web player for terminal session recordings.",
+  "version": "2.6.1",
+  "main": "resources/public/js/asciinema-player.js",
+  "homepage": "https://github.com/asciinema/asciinema-player",
+  "author": {
+    "name": "Marcin Kulik",
+    "email": "m@ku1ik.com",
+    "url": "http://ku1ik.com/"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/asciinema/asciinema-player.git"
+  },
+  "keywords": [
+    "player",
+    "asciicast",
+    "video",
+    "video-playback",
+    "terminal",
+    "unix",
+    "tty"
+  ],
+  "bugs": {
+    "url": "https://github.com/asciinema/asciinema-player/issues"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {},
+  "files": [
+    "resources/public/js/asciinema-player.js",
+    "resources/public/css/asciinema-player.css"
+  ],
+  "scripts": {
+    "build": "lein cljsbuild once release && lein less once",
+    "test": "lein doo phantom test once"
+  },
+  "devDependencies": {
+    "phantomjs": "^2.1.7"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   ],
   "scripts": {
     "build": "lein cljsbuild once release && lein less once",
+    "prepare": "npm run build",
     "test": "lein doo phantom test once"
   },
   "devDependencies": {

--- a/resources/.npmignore
+++ b/resources/.npmignore
@@ -1,0 +1,1 @@
+license.js


### PR DESCRIPTION
Hello,

This pull request aims to follow up with #54.

With the `package.json` file attached to this PR, the `npm pack` command builds the JS and CSS files using `lein` and generates a tgz file having the following structure:

```
package/package.json
package/CHANGELOG.md
package/LICENSE
package/README.md
package/resources/public/css/asciinema-player.css
package/resources/public/js/asciinema-player.js
```

So, publishing to `npmjs.org` becomes easy and can be automated using Travis CI (https://docs.travis-ci.com/user/deployment/npm/).