### PR TITLE
Fix typo in README Quick start, HTML missing endquote

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ inside an empty `<div>` element:
   ...
   <script src="/asciinema-player.min.js"></script>
   <script>
-    AsciinemaPlayer.create('/demo.cast', document.getElementById('demo));
+    AsciinemaPlayer.create('/demo.cast', document.getElementById('demo'));
   </script>
 </body>
 </html>


### PR DESCRIPTION
Minor typo: the HTML example in the quick start was missing a single quote

BTW: thank you for creating asciinema and easy self-hosting...it is awesome!!