### PR TITLE
Fix build instructions, point to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ It assumes you have obtained terminal session recording file by either:
 
 ### Use standalone player bundle in your HTML page
 
-Build the latest version of the player bundle by following the instructions at [Development](#Development) below. You
+Download latest version of the player bundle from
+[releases page](https://github.com/asciinema/asciinema-player/releases). You
 only need `asciinema-player.min.js` and `asciinema-player.css` files.
 
 First, add `asciinema-player.min.js`, `asciinema-player.css`and the `.cast` file of

--- a/README.md
+++ b/README.md
@@ -57,8 +57,7 @@ It assumes you have obtained terminal session recording file by either:
 
 ### Use standalone player bundle in your HTML page
 
-Download latest version of the player bundle from
-[releases page](https://github.com/asciinema/asciinema-player/releases). You
+Build the latest version of the player bundle by following the instructions at [Development](#Development) below. You
 only need `asciinema-player.min.js` and `asciinema-player.css` files.
 
 First, add `asciinema-player.min.js`, `asciinema-player.css`and the `.cast` file of
@@ -564,6 +563,7 @@ To build the project:
     git clone https://github.com/asciinema/asciinema-player
     cd asciinema-player
     git submodule update --init
+    rustup target add wasm32-unknown-unknown
     npm install
     npm run build
     npm run bundle


### PR DESCRIPTION
This PR addresses two issues:
- Current build instructions don't work out of the box and lead to errors due to wasm32-unknown-unknown missing.
- The README points to releases for latest artifacts however such releases don't ship the built artifacts so they need to be built from source

Without these changes, building the code from the current `develop` tree will lead to the following:

```bash
   Compiling log v0.4.14
   Compiling syn v1.0.77
   Compiling wasm-bindgen-shared v0.2.80
   Compiling serde v1.0.130
   Compiling cfg-if v1.0.0
   Compiling lazy_static v1.4.0
error[E0463]: can't find crate for `core`
  |
  = note: the `wasm32-unknown-unknown` target may not be installed
  = help: consider downloading the target with `rustup target add wasm32-unknown-unknown`

error[E0463]: can't find crate for `compiler_builtins`

For more information about this error, try `rustc --explain E0463`.
error: could not compile `cfg-if` due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
error: build failed
[!] (plugin rust) Error: Could not load /asciinema-player/src/vt/Cargo.toml (imported by src/core.js): Rust compilation failed
```