### PR TITLE
Bundle Nord theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ One of:
 * `"tango"`
 * `"solarized-dark"`
 * `"solarized-light"`
+* `"nord"`
 
 Defaults to `"asciinema"`.
 

--- a/src/less/asciinema-player.less
+++ b/src/less/asciinema-player.less
@@ -13,3 +13,4 @@
 @import "themes/_solarized-light";
 @import "themes/_seti";
 @import "themes/_monokai";
+@import "themes/_nord";

--- a/src/less/themes/_nord.less
+++ b/src/less/themes/_nord.less
@@ -1,0 +1,29 @@
+/*
+  Based on Nord: https://github.com/arcticicestudio/nord
+  Via: https://github.com/neilotoole/asciinema-theme-nord
+ */
+
+.asciinema-theme-nord {
+  @foreground: #ECEFF4;
+  @background: #2E3440;
+
+  @color0: #3B4252;
+  @color1: #BF616A;
+  @color2: #A3BE8C;
+  @color3: #EBCB8B;
+  @color4: #81A1C1;
+  @color5: #B48EAD;
+  @color6: #88C0D0;
+  @color7: #ECEFF4;
+  @color8: #3B4252;
+  @color9: #BF616A;
+  @color10: #A3BE8C;
+  @color11: #EBCB8B;
+  @color12: #81A1C1;
+  @color13: #B48EAD;
+  @color14: #88C0D0;
+  @color15: #ECEFF4;
+
+  .theme-base;
+  .theme-bright-is-bold;
+}


### PR DESCRIPTION
Per #204.

The theme is lifted from [neilotoole/asciinema-theme-nord](https://github.com/neilotoole/asciinema-theme-nord). That repo has some example usage.

<img width="1205" alt="example" src="https://user-images.githubusercontent.com/6013203/211772911-dff99945-7272-49f7-879e-bf0c6dbbbc02.png">
