### PR TITLE
Basic screen-reader support for playing asciicasts.

### DIFF
--- a/src/components/ControlBar.js
+++ b/src/components/ControlBar.js
@@ -51,13 +51,13 @@ export default props => {
         <span class="playback-button" onClick={e(props.onPlayClick)}>
           <Switch>
             <Match when={props.isPlaying}>
-              <svg version="1.1" viewBox="0 0 12 12" class="icon">
+              <svg version="1.1" viewBox="0 0 12 12" class="icon" aria-label="Pause" role="button" tabindex="0">
                 <path d="M1,0 L4,0 L4,12 L1,12 Z"></path>
                 <path d="M8,0 L11,0 L11,12 L8,12 Z"></path>
               </svg>
             </Match>
             <Match when={!props.isPlaying}>
-              <svg version="1.1" viewBox="0 0 12 12" class="icon">
+              <svg version="1.1" viewBox="0 0 12 12" class="icon" aria-label="Play" role="button" tabindex="0">
                 <path d="M1,0 L11,6 L1,12 Z"></path>
               </svg>
             </Match>
@@ -65,12 +65,12 @@ export default props => {
         </span>
       </Show>
 
-      <span class="timer">
+      <span class="timer" aria-readonly="true" role="textbox" tabindex="0">
         <span class="time-elapsed">{currentTime()}</span>
         <span class="time-remaining">{remainingTime()}</span>
       </span>
 
-      <span class="fullscreen-button" onClick={e(props.onFullscreenClick)} title="Toggle fullscreen mode">
+      <span class="fullscreen-button" onClick={e(props.onFullscreenClick)} title="Toggle fullscreen mode" aria-label="Toggle Fullscreen" role="button" tabindex="0">
         <svg version="1.1" viewBox="0 0 12 12" class="icon">
           <path d="M12,0 L7,0 L9,2 L7,4 L8,5 L10,3 L12,5 Z"></path>
           <path d="M0,12 L0,7 L2,9 L4,7 L5,8 L3,10 L5,12 Z"></path>

--- a/src/components/Line.js
+++ b/src/components/Line.js
@@ -49,6 +49,6 @@ export default props => {
   }
 
   return (
-    <span class="line" style={{height: props.height}}><Index each={segments()}>{s => <Segment text={s()[0]} attrs={s()[1]} extraClass={s()[2]} />}</Index></span>
+    <span class="line" style={{height: props.height}} role="paragraph"><Index each={segments()}>{s => <Segment text={s()[0]} attrs={s()[1]} extraClass={s()[2]} />}</Index></span>
   );
 }

--- a/src/components/Terminal.js
+++ b/src/components/Terminal.js
@@ -19,7 +19,7 @@ export default props => {
   const cursorRow = () => props.cursor?.[1];
 
   return (
-    <pre class="asciinema-terminal" classList={{ cursor: props.blink || props.cursorHold, blink: props.blink }} style={terminalStyle()} ref={props.ref}>
+    <pre class="asciinema-terminal" classList={{ cursor: props.blink || props.cursorHold, blink: props.blink }} style={terminalStyle()} ref={props.ref} aria-live="polite" tabindex="0">
       <For each={props.lines}>
         {(line, i) => <Line segments={line.segments} cursor={i() === cursorRow() ? cursorCol() : null} height={`${lineHeight()}em`} />}
       </For>


### PR DESCRIPTION
This adds tabindex values and labels to controls,
and adds screen-reader applicable line breaks to the output display.

Synthetic line breaks need to be added
because Screen-readers treat span elements as inline elements by default, regardless of CSS.

There are a lot of changes that can be done in future to benefit accessibility, but this at least allows for playback and streaming of events.

The most urgent next fix here would be to
isolate the parts of lines that have changed, and just read out those changes, using the aria-live role.