### PR TITLE
Place control bar below last terminal line

### DIFF
--- a/src/components/ControlBar.js
+++ b/src/components/ControlBar.js
@@ -46,7 +46,7 @@ export default props => {
   }
 
   return (
-    <div class="control-bar" classList={{ seekable: props.isSeekable }}>
+    <div class="control-bar" classList={{ seekable: props.isSeekable }} ref={props.ref}>
       <Show when={props.isPausable}>
         <span class="playback-button" onClick={e(props.onPlayClick)}>
           <Switch>

--- a/src/components/Player.js
+++ b/src/components/Player.js
@@ -22,6 +22,7 @@ export default props => {
     charH: null,
     bordersW: null,
     bordersH: null,
+    controlBarH: null,
     containerW: null,
     containerH: null,
     showControls: false,
@@ -46,6 +47,7 @@ export default props => {
   let wrapperRef;
   let playerRef;
   let terminalRef;
+  let controlBarRef;
   let resizeObserver;
 
   core.addEventListener('starting', () => {
@@ -92,6 +94,7 @@ export default props => {
       charH: terminalRef.clientHeight / terminalRows(),
       bordersW: terminalRef.offsetWidth - terminalRef.clientWidth,
       bordersH: terminalRef.offsetHeight - terminalRef.clientHeight,
+      controlBarH: controlBarRef.offsetHeight,
       containerW: wrapperRef.offsetWidth,
       containerH: wrapperRef.offsetHeight
     });
@@ -180,7 +183,7 @@ export default props => {
     let fit = props.fit ?? 'width';
 
     if (fit === 'both' || state.isFullscreen) {
-      const containerRatio = state.containerW / state.containerH;
+      const containerRatio = state.containerW / (state.containerH - state.controlBarH);
       const terminalRatio = terminalW / terminalH;
 
       if (containerRatio > terminalRatio) {
@@ -198,10 +201,10 @@ export default props => {
       return {
         scale: scale,
         width: state.containerW,
-        height: terminalH * scale
+        height: terminalH * scale + state.controlBarH
       };
     } else if (fit === 'height') {
-      const scale = state.containerH / terminalH;
+      const scale = (state.containerH - state.controlBarH) / terminalH;
 
       return {
         scale: scale,
@@ -365,7 +368,7 @@ export default props => {
     <div class="asciinema-player-wrapper" classList={{ hud: state.showControls }} tabIndex="-1" onKeyPress={onKeyPress} onKeyDown={onKeyPress} onMouseMove={wrapperOnMouseMove} onFullscreenChange={onFullscreenChange} onWebkitFullscreenChange={onFullscreenChange} ref={wrapperRef}>
       <div class={playerClass()} style={playerStyle()} onMouseLeave={playerOnMouseLeave} onMouseMove={() => showControls(true)} ref={playerRef}>
         <Terminal cols={terminalCols()} rows={terminalRows()} scale={terminalScale()} blink={state.blink} lines={state.lines} cursor={state.cursor} cursorHold={state.cursorHold} fontFamily={props.terminalFontFamily} lineHeight={props.terminalLineHeight} ref={terminalRef} />
-        <ControlBar currentTime={state.currentTime} remainingTime={state.remainingTime} progress={state.progress} isPlaying={state.coreState == 'playing'} isPausable={state.isPausable} isSeekable={state.isSeekable} onPlayClick={() => core.pauseOrResume()} onFullscreenClick={toggleFullscreen} onSeekClick={pos => core.seek(pos)} />
+        <ControlBar currentTime={state.currentTime} remainingTime={state.remainingTime} progress={state.progress} isPlaying={state.coreState == 'playing'} isPausable={state.isPausable} isSeekable={state.isSeekable} onPlayClick={() => core.pauseOrResume()} onFullscreenClick={toggleFullscreen} onSeekClick={pos => core.seek(pos)} ref={controlBarRef} />
         <Switch>
           <Match when={state.showStartOverlay}><StartOverlay onClick={() => core.play()} /></Match>
           <Match when={state.coreState == 'waiting'}><LoaderOverlay cols={terminalCols()} rows={terminalRows()} scale={terminalScale()} terminalFontFamily={props.terminalFontFamily} terminalLineHeight={props.terminalLineHeight} /></Match>

--- a/src/less/partials/_control-bar.less
+++ b/src/less/partials/_control-bar.less
@@ -13,9 +13,10 @@
     box-sizing: content-box;
     line-height: 1;
     position: absolute;
-    bottom: -35px;
+    bottom: 0;
     left: 0;
-    transition: bottom 0.15s linear;
+    opacity: 0;
+    transition: opacity 0.15s linear;
 
     // disable text selection:
     -webkit-touch-callout: none;
@@ -147,7 +148,7 @@
 
 .asciinema-player-wrapper {
   &.hud .control-bar {
-    bottom: 0px;
+    opacity: 1;
   }
 
   .in-fullscreen() {


### PR DESCRIPTION
This fixes problem with the control bar obscuring last 1-2 terminal lines during mouse movement. The fix keeps the control bar below terminal. Control bar still gets auto hidden when there's no user (mouse) activity, but now it disappears in place (via `opacity`).

Slight downside of this fix is that the space needed by the control bar is now permanently occupied regardless if it's visible or hidden, which for the most part looks like a little bit of extra padding on the bottom of the terminal. Still, from UX point of view I believe this is better.

It looks like this:

Control bar visible:

![image](https://user-images.githubusercontent.com/17589/224099694-c8d5a355-ecde-4f7c-bcf4-5c71b94a52de.png)

Control bar hidden:

![image](https://user-images.githubusercontent.com/17589/224099578-6d23ae8a-e40f-4454-a582-5fe96c4e55cc.png)
