### PR TITLE
Fix missing () on README asciinemaPlayer.addEventListener('input', ({…

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,7 +639,7 @@ This event can be used to play keyboard typing sound or display key presses on
 the screen amongst other use cases.
 
 ```javascript
-player.addEventListener('input', { data } => {
+player.addEventListener('input', ({data}) => {
   console.log('input!', JSON.stringify(data));
 })
 ```
@@ -653,7 +653,7 @@ const player = AsciinemaPlayer.create({
   inputOffset: -1.0
 }, document.getElementById('demo'));
 
-player.addEventListener('input', { data } => {
+player.addEventListener('input', ({data}) => {
   // this is now fired 1 sec ahead of original key press time
   playSound(data);
 })


### PR DESCRIPTION
Hi,
Thanks for the #220 resolution with #222 and v3.3.0 release. Great, fast, marvelous !
Sorry about being not around there the week you've worked on it.
I just tried to use it, I think there is a typo twice in the README examples. It doesn't work at least on my Firefox 102 ESR without addition a pair of parenthesis.
I think those typo are also in the snippet posted on the v3.3.0 release page.

Here a PR that I believe is more ECMA standard, but Javascript-like things aren't in my expertise at all.
Have a nice day,
Ludolpif