### PR TITLE
Implement typescript format parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ a user. If [preload](#preload) option is used, the function is invoked during
 player initialization (mounting in DOM).
 
 Provided `data` is parsed with built-in asciicast format parser by default (also
-see [Parsing other recording formats](#parsing-other-recording-formats)).
+see [Playing other recording formats](#playing-other-recording-formats)).
 
 Examples of supported `data` specifications:
 
@@ -266,22 +266,26 @@ AsciinemaPlayer.create(
 );
 ```
 
-### Parsing other recording formats
+### Playing other recording formats
 
 By default, a recording is parsed with built-in
 [asciicast](https://github.com/asciinema/asciinema/blob/develop/doc/asciicast-v2.md)
-format parser. However, if you happen to have a recording produced by other
-terminal session recording tool (e.g. ttyrec) or a log file that you want to
-animate, you can still play it in asciinema player, as long as you write a
-parser for it.
+format parser.
 
-Custom format parser can be used like this:
+If you have a recording produced by other terminal session recording tool (e.g.
+script, ttyrec) you can use one of [built-in file format
+parsers](src/parser/README.md#built-in-parsers), or [implement a custom parser
+function](src/parser/README.md#custom-parser).
+
+Recording format parser can be specified in the source argument to
+`AsciinemaPlayer.create` as a string (built-in) or function (custom):
 
 ```javascript
 AsciinemaPlayer.create({ url: url, parser: parser }, containerElement);
 ```
 
-See [Parsers](src/parser/README.md) for details on implementing a custom parser.
+See [Parsers](src/parser/README.md) for information on available built-in
+parsers and how to implement a custom parser.
 
 ## Options
 

--- a/src/driver/recording.js
+++ b/src/driver/recording.js
@@ -50,7 +50,17 @@ function recording(src, { feed, onInput, now, setTimeout, setState, logger }, { 
         data = data();
       }
 
-      return data;
+      if (!(data instanceof Promise)) {
+        data = Promise.resolve(data);
+      }
+
+      return data.then(value => {
+        if (typeof value === 'string' || value instanceof ArrayBuffer) {
+          return new Response(value);
+        } else {
+          return value;
+        }
+      });
     } else {
       throw 'failed fetching recording file: url/data missing in src';
     }

--- a/src/driver/recording.js
+++ b/src/driver/recording.js
@@ -40,24 +40,30 @@ function recording(src, { feed, onInput, now, setTimeout, setState, logger }, { 
     return { cols, rows, duration };
   }
 
-  async function doFetch({ url, data, fetchOpts = {} }) {
-    if (url !== undefined) {
-      const response = await fetch(url, fetchOpts);
-
-      if (!response.ok) {
-        throw `failed fetching recording file: ${response.statusText} (${response.status})`;
-      }
-
-      return await response.text();
+  function doFetch({ url, data, fetchOpts = {} }) {
+    if (typeof url === 'string') {
+      return doFetchOne(url, fetchOpts);
+    } else if (Array.isArray(url)) {
+      return Promise.all(url.map(url => doFetchOne(url, fetchOpts)));
     } else if (data !== undefined) {
       if (typeof data === 'function') {
         data = data();
       }
 
-      return await data;
+      return data;
     } else {
       throw 'failed fetching recording file: url/data missing in src';
     }
+  }
+
+  async function doFetchOne(url, fetchOpts) {
+    const response = await fetch(url, fetchOpts);
+
+    if (!response.ok) {
+      throw `failed fetching recording file: ${response.statusText} (${response.status})`;
+    }
+
+    return await response.text();
   }
 
   function delay(targetTime) {

--- a/src/driver/recording.js
+++ b/src/driver/recording.js
@@ -60,7 +60,7 @@ function recording(src, { feed, onInput, now, setTimeout, setState, logger }, { 
     const response = await fetch(url, fetchOpts);
 
     if (!response.ok) {
-      throw `failed fetching recording file: ${response.statusText} (${response.status})`;
+      throw `failed fetching recording from ${url}: ${response.status} ${response.statusText}`;
     }
 
     return await response.text();

--- a/src/driver/recording.js
+++ b/src/driver/recording.js
@@ -22,7 +22,7 @@ function recording(src, { feed, onInput, now, setTimeout, setState, logger }, { 
     const { parser, minFrameTime, inputOffset, dumpFilename } = src;
 
     const recording = prepare(
-      parser(await doFetch(src)),
+      await parser(await doFetch(src)),
       logger,
       { idleTimeLimit, startAt, minFrameTime, inputOffset }
     );
@@ -63,7 +63,7 @@ function recording(src, { feed, onInput, now, setTimeout, setState, logger }, { 
       throw `failed fetching recording from ${url}: ${response.status} ${response.statusText}`;
     }
 
-    return await response.text();
+    return response;
   }
 
   function delay(targetTime) {

--- a/src/driver/test.js
+++ b/src/driver/test.js
@@ -1,4 +1,4 @@
-import { parseAsciicast } from '../parser/asciicast';
+import parseAsciicast from '../parser/asciicast';
 
 
 function test(src, callbacks, opts) {

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import { recording } from "./driver/recording";
 import { test } from "./driver/test";
 import { websocket } from "./driver/websocket";
 import { eventsource } from "./driver/eventsource";
-import { parseAsciicast } from "./parser/asciicast";
+import parseAsciicast from "./parser/asciicast";
 import parseTypescript from "./parser/typescript";
 
 const drivers = new Map([

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,19 @@ import { test } from "./driver/test";
 import { websocket } from "./driver/websocket";
 import { eventsource } from "./driver/eventsource";
 import { parseAsciicast } from "./parser/asciicast";
+import parseTypescript from "./parser/typescript";
+
+const drivers = new Map([
+  ['recording', recording],
+  ['websocket', websocket],
+  ['eventsource', eventsource],
+  ['test', test]
+]);
+
+const parsers = new Map([
+  ['asciicast', parseAsciicast],
+  ['typescript', parseTypescript]
+]);
 
 function create(src, elem, opts = {}) {
   const logger = opts.logger ?? new DummyLogger();
@@ -81,16 +94,19 @@ function getDriver(src) {
     src.driver = 'recording';
   }
 
-  if (src.driver == 'recording' && src.parser === undefined) {
-    src.parser = parseAsciicast;
-  }
+  if (src.driver == 'recording') {
+    if (src.parser === undefined) {
+      src.parser = 'asciicast';
+    }
 
-  const drivers = new Map([
-    ['recording', recording],
-    ['websocket', websocket],
-    ['eventsource', eventsource],
-    ['test', test]
-  ]);
+    if (typeof src.parser === 'string') {
+      if (parsers.has(src.parser)) {
+        src.parser = parsers.get(src.parser);
+      } else {
+        throw `unknown parser: ${src.parser}`;
+      }
+    }
+  }
 
   if (drivers.has(src.driver)) {
     const driver = drivers.get(src.driver);

--- a/src/parser/README.md
+++ b/src/parser/README.md
@@ -45,9 +45,9 @@ The exact above recording object would be returned from asciicast parser when
 invoked with following input text:
 
 ```javascript
-import { parseAsciicast } from "asciinema-player/parser/asciicast";
+import parse from "asciinema-player/parser/asciicast";
 
-parseAsciicast('{ "version": 2, "width": 80, "height": 24 }\n[1.0, "o", "hello "]\n[2.0, "o", "world!"]\n');
+parse('{ "version": 2, "width": 80, "height": 24 }\n[1.0, "o", "hello "]\n[2.0, "o", "world!"]\n');
 ```
 
 ## Custom parser

--- a/src/parser/README.md
+++ b/src/parser/README.md
@@ -5,6 +5,15 @@ format into a simple object representing a recording. Once the player fetches a
 file, it runs its contents through a parser, which turns it into a recording
 object used by player's [recording driver](../driver/recording.js).
 
+Default parser used by the player is [asciicast parser](#asciicast), however
+another [built-in](#built-in-parsers) or [custom parser](#custom-parser) can be
+used by including `parser` option in source argument of
+`AsciinemaPlayer.create`:
+
+```javascript
+AsciinemaPlayer.create({ url: url, parser: parser }, containerElement);
+```
+
 ## Data model of a recording
 
 asciinema player uses very simple internal representation of a recording. The
@@ -32,35 +41,75 @@ Example recording in its internal representation:
 }
 ```
 
-## Default parser
+## Built-in parsers
 
-Default parser used by the player is [asciicast](asciicast.js), which handles
-both [asciicast
+Built-in parser can be used by passing the parser name (string) as `parser`
+option:
+
+```javascript
+AsciinemaPlayer.create({ url: url, parser: 'built-in-parser-name' }, containerElement);
+```
+
+### asciicast
+
+`asciicast` parser handles both [asciicast
 v1](https://github.com/asciinema/asciinema/blob/develop/doc/asciicast-v1.md) and
 [asciicast
 v2](https://github.com/asciinema/asciinema/blob/develop/doc/asciicast-v2.md)
-file formats.
+file formats produced by [asciinema
+recorder](https://github.com/asciinema/asciinema).
 
-The exact above recording object would be returned from asciicast parser when
-invoked with following input text:
+This parser is the default and does not have to be explicitly selected.
+
+### typescript
+
+`typescript` parser handles recordings in typescript format (not to be confused
+with Typescript language) produced by venerable [script
+command](https://www.man7.org/linux/man-pages/man1/script.1.html).
+
+This parser supports both "classic" and "advanced" logging formats, including
+input streams.
+
+Usage:
 
 ```javascript
-import parse from "asciinema-player/parser/asciicast";
+AsciinemaPlayer.create({
+  url: ['/demo.timing', '/demo.data'],
+  parser: 'typescript'
+}, document.getElementById('demo'));
+```
 
-parse('{ "version": 2, "width": 80, "height": 24 }\n[1.0, "o", "hello "]\n[2.0, "o", "world!"]\n');
+Note `url` above being an array of URLs pointing to typescript timing and data
+files.
+
+Usage for 3 file variant - timing file + output file + input file (created when
+recording with `script --log-in <file>`):
+
+```javascript
+AsciinemaPlayer.create({
+  url: ['/demo.timing', '/demo.output', '/demo.input'],
+  parser: 'typescript'
+}, document.getElementById('demo'));
 ```
 
 ## Custom parser
 
-Custom format parser can be built by implementing a function which takes file
-content and returns a value conforming to the above data model.
+Custom format parser can be used by using a _function_ as `parser` option:
+
+```javascript
+AsciinemaPlayer.create({ url: url, parser: myParserFunction }, containerElement);
+```
+
+Custom parser function takes a [Response
+object](https://developer.mozilla.org/en-US/docs/Web/API/Response) and returns
+an object conforming to the [recording data model](#data-model-of-a-recording).
 
 The following example illustrates implementation of a custom parser:
 
 ```javascript
 import * as AsciinemaPlayer from 'asciinema-player';
 
-function parse(text) {
+function parse(response) {
   return {
     cols: 80,
     rows: 24,
@@ -82,15 +131,17 @@ function.
 
 This parser is not quite there though because it ignores downloaded file's
 content, always returning hardcoded output. Also, `cols` and `rows` are made up
-as well - if possible they should reflect the size of a terminal at the time of
-recording, otherwise their values should be chosen to make the recording look
-legible. The example illustrates what kind of data the player expects though.
+as well - if possible they should be extracted from the file and reflect the
+size of a terminal at the time recording session happened. The example
+illustrates what kind of data the player expects though.
 
 A more realistic example, where content of a file is actually used to construct
 output, could look like this:
 
 ```javascript
-function parseLogs(text) {
+async function parseLogs(response) {
+  const text = await response.text();
+
   return {
     cols: 80,
     rows: 24,
@@ -122,7 +173,8 @@ For example:
 ```
 
 ```javascript
-function parseLogs(text) {
+async function parseLogs(response) {
+  const text = await response.text();
   const pattern = /^([\d.]+) (.*)/;
 
   return {
@@ -140,13 +192,16 @@ Here's slightly more advanced parser, for [Simon Jansen's Star Wars
 Asciimation](https://www.asciimation.co.nz/):
 
 ```javascript
-function parseAsciimation(text) {
-  const LINES_PER_FRAME = 14;
-  const FRAME_DELAY = 67;
+const LINES_PER_FRAME = 14;
+const FRAME_DELAY = 67;
+const COLUMNS = 67;
+
+async function parseAsciimation(response) {
+  const text = await response.text();
   const lines = text.split('\n');
 
   return {
-    cols: 67,
+    cols: COLUMNS,
     rows: LINES_PER_FRAME - 1,
 
     output: function*() {

--- a/src/parser/asciicast.js
+++ b/src/parser/asciicast.js
@@ -1,9 +1,13 @@
 import Stream from '../stream';
 
 
-function parseAsciicast(data) {
+async function parseAsciicast(data) {
   let header;
   let events;
+
+  if (data instanceof Response) {
+    data = await data.text();
+  }
 
   if (typeof data === 'string') {
     const result = parseJsonl(data);

--- a/src/parser/asciicast.js
+++ b/src/parser/asciicast.js
@@ -6,7 +6,7 @@ function parseAsciicast(data) {
   let events;
 
   if (typeof data === 'string') {
-    const result = parseJsonl(data);;
+    const result = parseJsonl(data);
 
     if (result !== undefined) {
       header = result.header;

--- a/src/parser/asciicast.js
+++ b/src/parser/asciicast.js
@@ -1,7 +1,7 @@
 import Stream from '../stream';
 
 
-async function parseAsciicast(data) {
+async function parse(data) {
   let header;
   let events;
 
@@ -94,4 +94,5 @@ function unparseAsciicastV2(recording) {
   return `${header}\n${events}\n`;
 }
 
-export { parseAsciicast, unparseAsciicastV2 };
+export default parse;
+export { parse, unparseAsciicastV2 };

--- a/src/parser/asciicast.js
+++ b/src/parser/asciicast.js
@@ -6,17 +6,14 @@ async function parse(data) {
   let events;
 
   if (data instanceof Response) {
-    data = await data.text();
-  }
-
-  if (typeof data === 'string') {
-    const result = parseJsonl(data);
+    const text = await data.text();
+    const result = parseJsonl(text);
 
     if (result !== undefined) {
       header = result.header;
       events = result.events;
     } else {
-      header = JSON.parse(data);
+      header = JSON.parse(text);
     }
   } else if (typeof data === 'object' && typeof data.version === 'number') {
     header = data;

--- a/src/parser/typescript.js
+++ b/src/parser/typescript.js
@@ -1,0 +1,67 @@
+async function parseTypescript(responses) {
+  const utfDecoder = new TextDecoder();
+  let cols;
+  let rows;
+
+  let timing = (await responses[0].text())
+    .split('\n')
+    .filter(line => line.length > 0)
+    .map(line => line.split(' '));
+
+  if (timing[0].length < 3) {
+    timing = timing.map(entry => ['O', entry[0], entry[1]]);
+  }
+
+  const buffer = await responses[1].arrayBuffer();
+  const array = new Uint8Array(buffer);
+  const dataOffset = array.findIndex(byte => byte == 0x0a) + 1;
+  const header = utfDecoder.decode(array.slice(0, dataOffset));
+  const sizeMatch = header.match(/COLUMNS="(\d+)" LINES="(\d+)"/);
+
+  if (sizeMatch !== null) {
+    cols = parseInt(sizeMatch[1], 10);
+    rows = parseInt(sizeMatch[2], 10);
+  }
+
+  const stdout = { array, cursor: dataOffset };
+  let stdin = stdout;
+
+  if (responses[2] !== undefined) {
+    const buffer = await responses[2].arrayBuffer();
+    const array = new Uint8Array(buffer);
+    stdin = { array, cursor: dataOffset };
+  }
+
+  const output = [];
+  const input = [];
+  let time = 0;
+
+  for (const entry of timing) {
+    time += parseFloat(entry[1]);
+
+    if (entry[0] === 'O') {
+      const count = parseInt(entry[2], 10);
+      const bytes = stdout.array.slice(stdout.cursor, stdout.cursor + count);
+      const text = utfDecoder.decode(bytes);
+      output.push([time, text]);
+      stdout.cursor += count;
+    } else if (entry[0] === 'I') {
+      const count = parseInt(entry[2], 10);
+      const bytes = stdin.array.slice(stdin.cursor, stdin.cursor + count);
+      const text = utfDecoder.decode(bytes);
+      input.push([time, text]);
+      stdin.cursor += count;
+    } else if (entry[0] === 'H' && entry[2] === 'COLUMNS') {
+      cols = parseInt(entry[3], 10);
+    } else if (entry[0] === 'H' && entry[2] === 'LINES') {
+      rows = parseInt(entry[3], 10);
+    }
+  }
+
+  cols = cols ?? 80;
+  rows = rows ?? 24;
+
+  return { cols, rows, output, input };
+}
+
+export default parseTypescript;

--- a/src/parser/typescript.js
+++ b/src/parser/typescript.js
@@ -1,4 +1,4 @@
-async function parseTypescript(responses) {
+async function parse(responses) {
   const utfDecoder = new TextDecoder();
   let cols;
   let rows;
@@ -64,4 +64,4 @@ async function parseTypescript(responses) {
   return { cols, rows, output, input };
 }
 
-export default parseTypescript;
+export default parse;


### PR DESCRIPTION
This adds a parser for recordings in venerable [typescript format](https://www.man7.org/linux/man-pages/man1/script.1.html) (not to be confused with Typescript language).

2 file variant: timing file + output file, or timing + combined output/input file ("advanced" format):

```javascript
AsciinemaPlayer.create({
  url: ['/demo.timing', '/demo.data'],
  parser: 'typescript'
}, document.getElementById('demo'));
```

3 file variant: timing file + output file + input file:

```javascript
AsciinemaPlayer.create({
  url: ['/demo.timing', '/demo.output', '/demo.input'],
  parser: 'typescript'
}, document.getElementById('demo'));
```