### PR TITLE
Implement ttyrec format parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,12 +273,12 @@ By default, a recording is parsed with built-in
 format parser.
 
 If you have a recording produced by other terminal session recording tool (e.g.
-script, ttyrec) you can use one of [built-in file format
+script, termrec, ttyrec) you can use one of [built-in file format
 parsers](src/parser/README.md#built-in-parsers), or [implement a custom parser
 function](src/parser/README.md#custom-parser).
 
 Recording format parser can be specified in the source argument to
-`AsciinemaPlayer.create` as a string (built-in) or function (custom):
+`AsciinemaPlayer.create` as a string (built-in) or a function (custom):
 
 ```javascript
 AsciinemaPlayer.create({ url: url, parser: parser }, containerElement);

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import { websocket } from "./driver/websocket";
 import { eventsource } from "./driver/eventsource";
 import parseAsciicast from "./parser/asciicast";
 import parseTypescript from "./parser/typescript";
+import parseTtyrec from "./parser/ttyrec";
 
 const drivers = new Map([
   ['recording', recording],
@@ -19,7 +20,8 @@ const drivers = new Map([
 
 const parsers = new Map([
   ['asciicast', parseAsciicast],
-  ['typescript', parseTypescript]
+  ['typescript', parseTypescript],
+  ['ttyrec', parseTtyrec],
 ]);
 
 function create(src, elem, opts = {}) {

--- a/src/parser/README.md
+++ b/src/parser/README.md
@@ -92,6 +92,25 @@ AsciinemaPlayer.create({
 }, document.getElementById('demo'));
 ```
 
+### ttyrec
+
+`ttyrec` parser handles recordings in [ttyrec
+format](https://nethackwiki.com/wiki/Ttyrec) produced by
+[ttyrec](http://0xcc.net/ttyrec/), [termrec](http://angband.pl/termrec.html) or
+[ipbt](https://www.chiark.greenend.org.uk/~sgtatham/ipbt/) amongst others.
+
+This parser understands `\e[8;Y;Xt` terminal size sequence injected into the
+first frame by termrec.
+
+Usage:
+
+```javascript
+AsciinemaPlayer.create({
+  url: '/demo.ttyrec',
+  parser: 'ttyrec'
+}, document.getElementById('demo'));
+```
+
 ## Custom parser
 
 Custom format parser can be used by using a _function_ as `parser` option:

--- a/src/parser/ttyrec.js
+++ b/src/parser/ttyrec.js
@@ -1,0 +1,53 @@
+async function parse(response) {
+  const utfDecoder = new TextDecoder();
+  const buffer = await response.arrayBuffer();
+  const array = new Uint8Array(buffer);
+  const firstFrame = parseFrame(array);
+  const baseTime = firstFrame.time;
+  const firstFrameText = utfDecoder.decode(firstFrame.data);
+  const sizeMatch = firstFrameText.match(/\x1b\[8;(\d+);(\d+)t/);
+  const output = [];
+  let cols = 80;
+  let rows = 24;
+
+  if (sizeMatch !== null) {
+    cols = parseInt(sizeMatch[2], 10);
+    rows = parseInt(sizeMatch[1], 10);
+  }
+
+  let cursor = 0;
+  let frame = parseFrame(array);
+
+  while (frame !== undefined) {
+    const time = frame.time - baseTime;
+    const text = utfDecoder.decode(frame.data);
+    output.push([time, text]);
+    cursor += frame.len;
+    frame = parseFrame(array.slice(cursor));
+  }
+
+  return { cols, rows, output, input: [] };
+}
+
+function parseFrame(array) {
+  if (array.length < 13) return;
+
+  const time = parseTimestamp(array.slice(0, 8));
+  const len = parseNumber(array.slice(8, 12));
+  const data = array.slice(12, 12 + len);
+
+  return { time, data, len: len + 12 };
+}
+
+function parseNumber(array) {
+  return array[0] + array[1] * 256 + array[2] * 256 * 256 + array[3] * 256 * 256 * 256; 
+}
+
+function parseTimestamp(array) {
+  const sec = parseNumber(array.slice(0, 4));
+  const usec = parseNumber(array.slice(4, 8));
+
+  return sec + (usec / 1000000);
+}
+
+export default parse;

--- a/src/parser/ttyrec.js
+++ b/src/parser/ttyrec.js
@@ -26,7 +26,7 @@ async function parse(response) {
     frame = parseFrame(array.slice(cursor));
   }
 
-  return { cols, rows, output, input: [] };
+  return { cols, rows, output };
 }
 
 function parseFrame(array) {


### PR DESCRIPTION
`ttyrec` parser handles recordings in [ttyrec format](https://nethackwiki.com/wiki/Ttyrec) produced by [ttyrec](http://0xcc.net/ttyrec/), [termrec](http://angband.pl/termrec.html) or [ipbt](https://www.chiark.greenend.org.uk/~sgtatham/ipbt/) amongst others.

This parser understands `\e[8;Y;Xt` terminal size sequence injected into the first frame by termrec.

Usage:

```javascript
AsciinemaPlayer.create({
  url: '/demo.ttyrec',
  parser: 'ttyrec'
}, document.getElementById('demo'));
```
