### PR TITLE
Add idle idleTimeLimit to websocket + eventsource drivers

### DIFF
--- a/src/driver/eventsource.js
+++ b/src/driver/eventsource.js
@@ -2,7 +2,7 @@ import getBuffer from '../buffer';
 import { Clock, NullClock } from '../clock';
 import { PrefixedLogger } from '../logging';
 
-function eventsource({ url, bufferTime = 0.1, minFrameTime }, { feed, reset, setState, logger }) {
+function eventsource({ url, bufferTime = 0.1, minFrameTime }, { feed, reset, setState, logger }, { idleTimeLimit }) {
   logger = new PrefixedLogger(logger, 'eventsource: ');
   let es;
   let buf;
@@ -10,7 +10,7 @@ function eventsource({ url, bufferTime = 0.1, minFrameTime }, { feed, reset, set
 
   function initBuffer(baseStreamTime) {
     if (buf !== undefined) buf.stop();
-    buf = getBuffer(feed, (t) => clock.setTime(t), bufferTime, baseStreamTime, minFrameTime);
+    buf = getBuffer(feed, (t) => clock.setTime(t), bufferTime, baseStreamTime, minFrameTime,idleTimeLimit);
   }
 
   return {

--- a/src/driver/websocket.js
+++ b/src/driver/websocket.js
@@ -6,7 +6,7 @@ function exponentialDelay(attempt) {
   return Math.min(500 * Math.pow(2, attempt), 5000);
 }
 
-function websocket({ url, bufferTime = 0.1, reconnectDelay = exponentialDelay, minFrameTime }, { feed, reset, setState, logger }) {
+function websocket({ url, bufferTime = 0.1, reconnectDelay = exponentialDelay, minFrameTime }, { feed, reset, setState, logger }, { idleTimeLimit }) {
   logger = new PrefixedLogger(logger, 'websocket: ');
   const utfDecoder = new TextDecoder();
   let socket;
@@ -18,7 +18,7 @@ function websocket({ url, bufferTime = 0.1, reconnectDelay = exponentialDelay, m
 
   function initBuffer(baseStreamTime) {
     if (buf !== undefined) buf.stop();
-    buf = getBuffer(feed, (t) => clock.setTime(t), bufferTime, baseStreamTime, minFrameTime);
+    buf = getBuffer(feed, (t) => clock.setTime(t), bufferTime, baseStreamTime, minFrameTime, idleTimeLimit);
   }
 
   function detectProtocol(event) {


### PR DESCRIPTION
I'm building a lightweight multi-terminal live streaming project for my own use running labs/demos/etc, and for my use case it was useful to be able to speed through the previously recorded content to get up to the live feed, so I added `idleTimeLimit` support to the `websocket` and `eventsource` drivers.

If this is an improvement that seems worth the effort, feel free to merge this or give feedback so I can get it up to your standard

If this is a niche use case and not worth the time, feel free to close this out

Either way, I'm loving the project, and I appreciate all the hard work!