### PR TITLE
Add "type": "module" to package.json to fix import error

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "files": [
     "dist"
   ],
+  "type": "module",
   "scripts": {
     "build": "rollup -c --environment production",
     "bundle": "rollup -c rollup.config.bundle.mjs --environment production && lessc src/less/asciinema-player.less >dist/bundle/asciinema-player.css",


### PR DESCRIPTION
Fixes #259

Since I'm not super familiar with the library (I only found it about an hour ago) I can't be 100% certain that this works correctly. There aren't any test cases I could run, but `npm run build` did seem to bundle the library correctly once I installed the wasm target for `cargo`.

I hope this helps!