### PR TITLE
Tell screen readers to not announce the whole content everytime it changes

### DIFF
--- a/src/components/Terminal.js
+++ b/src/components/Terminal.js
@@ -24,7 +24,7 @@ export default (props) => {
       classList={{ "ap-cursor-on": props.blink || props.cursorHold, "ap-blink": props.blink }}
       style={style()}
       ref={props.ref}
-      aria-live="polite"
+      aria-live="off"
       tabindex="0"
     >
       <For each={props.lines}>


### PR DESCRIPTION
Setting `aria-live="polite"` on an element means that screen readers will announce its content whenever it changes, as soon as the user is done reading text anywhere in the page. Since a terminal recording will generate constant updates, this make it very hard to consult a web page if the player is running, especially if it is starting automatically on page load.

The use case which led me here is [Serpent OS's landing page](https://serpentos.com/).