### PR TITLE
Fix overseek crash (bug #282)

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -110,8 +110,16 @@ class Idle extends State {
     await this.play();
   }
 
-  seek(where) {
-    return this.driver.seek(where);
+  async seek(where) {
+    const result = await this.driver.seek(where);
+
+    const remaining = this.core.getRemainingTime?.();
+
+    if (result && remaining === 0) {
+      this.core._setState("ended");
+    }
+
+    return result;
   }
 
   step(n) {
@@ -169,12 +177,20 @@ class EndedState extends State {
   }
 
   async seek(where) {
-    if (await this.driver.seek(where)) {
-      this.core._setState('idle');
+    const result = await this.driver.seek(where);
+
+    if (!result) {
+      return false;
+    }
+
+    const remaining = this.core.getRemainingTime?.();
+
+    if (remaining === 0) {
       return true;
     }
 
-    return false;
+    this.core._setState("idle");
+    return true;
   }
 }
 


### PR DESCRIPTION
Since at least v3.9.0 player crashes with `Uncaught (in promise) already ended` when the user seeks past the end of timeline then presses 'play' (#282)

Since v.3.11.0 the bug started to behave differently: when the playback reaches the end, the only valid move is to press 'play' which re-starts the playback from the beginning; any seek+play after reaching the end breaks the player with `Uncaught (in promise) not ended`

* fcd5f7f reverts to the previous buggy behavior with `already ended`
* 085e83c fixes the bug so that seeking past the end behaves the same as reaching the end

Didn't run the testsuite, not sure if the patches match the style and logic of the codebase—please verify