### PR TITLE
Add runtime speed control via player.setSpeed()

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -390,6 +390,14 @@ class Core {
     return this._withState((state) => state.unmute());
   }
 
+  setSpeed(speed) {
+    this.speed = speed;
+
+    if (this.driver.setSpeed) {
+      this.driver.setSpeed(speed);
+    }
+  }
+
   getLine(n, cursorOn) {
     return this.vt.getLine(n, cursorOn);
   }

--- a/src/driver/recording.js
+++ b/src/driver/recording.js
@@ -546,6 +546,26 @@ function recording(
     }
   }
 
+  function setSpeed(newSpeed) {
+    const currentPlaybackMs = eventTimeoutId
+      ? now() - startTime
+      : (pauseElapsedTime ?? 0);
+
+    if (eventTimeoutId) {
+      speed = newSpeed;
+      startTime = now() - currentPlaybackMs;
+      cancelNextEvent();
+      scheduleNextEvent();
+    } else {
+      speed = newSpeed;
+    }
+
+    if (audioElement) {
+      audioElement.currentTime = currentPlaybackMs / 1000 / newSpeed;
+      audioElement.playbackRate = newSpeed;
+    }
+  }
+
   return {
     init,
     play,
@@ -557,6 +577,7 @@ function recording(
     mute,
     unmute,
     getCurrentTime,
+    setSpeed,
   };
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,7 @@ function create(src, elem, opts = {}) {
     play: () => ready.then(core.play.bind(core)),
     pause: () => ready.then(core.pause.bind(core)),
     seek: (pos) => ready.then(() => core.seek(pos)),
+    setSpeed: (speed) => ready.then(() => core.setSpeed(speed)),
   };
 
   player.addEventListener = (name, callback) => {

--- a/src/ui.js
+++ b/src/ui.js
@@ -18,6 +18,7 @@ function create(src, elem, workerUrl, opts = {}) {
     play: () => ready.then(core.play.bind(core)),
     pause: () => ready.then(core.pause.bind(core)),
     seek: (pos) => ready.then(() => core.seek(pos)),
+    setSpeed: (speed) => ready.then(() => core.setSpeed(speed)),
   };
 
   player.addEventListener = (name, callback) => {
@@ -102,6 +103,10 @@ class CoreWorkerProxy {
 
   getDuration() {
     return this._sendCommand('getDuration');
+  }
+
+  setSpeed(speed) {
+    return this._sendCommand('setSpeed', speed);
   }
 
   addEventListener(eventName, handler) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -41,6 +41,8 @@ function invoke(method, params) {
       return core.seek(params);
     case "step":
       return core.step(params);
+    case "setSpeed":
+      return core.setSpeed(params);
     case "getCurrentTime":
       return core.getCurrentTime();
     case "getRemainingTime":


### PR DESCRIPTION
This PR exposes a `setSpeed(speed)` method on the public player API, allowing callers to change playback speed at any time without unmounting and remounting the player.

The recording driver carries out the change inline:
- While playing: the current playback position is captured, speed is updated, and startTime is recalculated so the position is preserved under the new rate. The next scheduled event is cancelled and rescheduled with the corrected timing.
- While paused: only speed is updated. pauseElapsedTime is already expressed in playback-time units, so resume() picks up the new rate automatically with no extra work.
- Audio: audioElement.playbackRate is set directly, which is natively supported by HTMLMediaElement. The audio current time is also updated accordingly.

The method is wired through the full call stack:
  player.setSpeed()  (index.js / ui.js public API) → Core.setSpeed()  (core.js) → driver.setSpeed() (recording.js)

The split-mode (Web Worker) path is also covered: CoreWorkerProxy sends a "setSpeed" command to the worker, and the worker's dispatcher routes it to core.setSpeed().