### PR TITLE
docs: fix GitHub capitalization in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to asciinema
 
-First, if you're opening a Github issue make sure it goes to the correct repository:
+First, if you're opening a GitHub issue make sure it goes to the correct repository:
 
 * [asciinema/asciinema](https://github.com/asciinema/asciinema/issues) - command-line recorder
 * [asciinema/asciinema.org](https://github.com/asciinema/asciinema-server/issues) - public website hosting recordings
@@ -8,7 +8,7 @@ First, if you're opening a Github issue make sure it goes to the correct reposit
 
 ## Reporting bugs
 
-Open an issue in Github issue tracker.
+Open an issue in GitHub issue tracker.
 Tell us what's the problem and include steps to reproduce it (reliably).
 Including your OS/browser/terminal name and version in the report would be great.
 
@@ -22,7 +22,7 @@ If you found a bug and made a patch for it:
 ## Requesting new features
 
 We welcome all ideas.
-If you believe most asciinema users would benefit from implementing your idea then feel free to open a Github issue.
+If you believe most asciinema users would benefit from implementing your idea then feel free to open a GitHub issue.
 However, as this is an open-source project maintained by a small team of volunteers we simply can't implement all of them due to limited resources. Please keep that in mind.
 
 ## Proposing features/changes (pull requests)
@@ -31,6 +31,6 @@ If you want to propose code change, either introducing a new feature or improvin
 
 ## Asking for help
 
-Github issue tracker is not a support forum. If you need help then either [join
+GitHub issue tracker is not a support forum. If you need help then either [join
 #asciinema IRC channel on Libera.Chat](https://web.libera.chat/gamja/#asciinema) or 
 ask a question on [asciinema community forum](https://discourse.asciinema.org/).


### PR DESCRIPTION
## Summary
- fix `GitHub` capitalization in `CONTRIBUTING.md`.

## Related issue
- N/A; trivial docs/comment fix.

## Guideline alignment
- Followed https://github.com/asciinema/asciinema-player/blob/develop/CONTRIBUTING.md and kept this to a single documentation file.

## Validation
- Not run; docs/comment-only change.
