### PR TITLE
Fix typo in VT span merge comment

### DIFF
--- a/src/vt/src/lib.rs
+++ b/src/vt/src/lib.rs
@@ -232,7 +232,7 @@ impl Vt {
                                 && span.is_underline() == pen.is_underline()
                                 && span.is_strikethrough() == pen.is_strikethrough()) =>
                     // spaces with the same underline/strike-through values can be safely merged
-                    // into the previous span regardles of their other attr values (color, bold,
+                    // into the previous span regardless of their other attr values (color, bold,
                     // italic etc), reducing the overall number of text spans representing a row
                     {
                         span.text_len += 1;


### PR DESCRIPTION
## Summary

Fix a typo in the VT span-merging comment by changing `regardles` to `regardless`.

## Related issue

N/A, trivial comment fix.

## Guideline alignment

Single-file, non-behavioral wording change.

## Validation/testing note

Not run; comment-only change.