### PR TITLE
Guard against non-array markers option (null crashes the player)

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -24,7 +24,7 @@ class Core {
     this.preload = opts.preload;
     this.startAt = parseNpt(opts.startAt);
     this.poster = this._parsePoster(opts.poster);
-    this.markers = opts.markers;
+    this.markers = this._normalizeMarkers(opts.markers);
     this.pauseOnMarkers = opts.pauseOnMarkers;
     this.audioUrl = opts.audioUrl;
     this.initPromise = null;
@@ -280,6 +280,17 @@ class Core {
     }
 
     return;
+  }
+
+  // Recording drivers (see e.g. driver/recording/full.js) only guard against
+  // `undefined` before wrapping markers in a Stream, so a non-array value
+  // (notably `null`, which host apps like asciinema-server pass for
+  // markerless recordings) reaches `new Stream(markers)` and throws. Coerce
+  // anything that isn't an array to `undefined` here, at the API boundary.
+  _normalizeMarkers(markers) {
+    if (Array.isArray(markers)) {
+      return markers.map((m) => (typeof m === "number" ? [m, ""] : m));
+    }
   }
 }
 


### PR DESCRIPTION
## What

`opts.markers` was assigned to `this.markers` verbatim in `Core`'s constructor, then passed straight through to the recording driver (e.g. `driver/recording/full.js`), which only guards with `if (markers !== undefined)` before wrapping it in `new Stream(markers)`.

A `markers` value of `null` (rather than `undefined`) passes that guard and reaches `new Stream(null)`, whose constructor unconditionally calls `input[Symbol.iterator]()` — throwing `TypeError: Cannot read properties of null (reading 'next')`. The player's own error handling then swallows this into the generic error overlay, so it's not obvious from the outside what happened.

## Why this matters

Host applications that always populate every player option — passing `null` for anything unset rather than omitting the key — hit this on every markerless recording. [asciinema-server](https://github.com/asciinema/asciinema-server) is one such caller: `player_opts/2` always includes `markers: markers(asciicast.markers)`, which is `nil` (→ JSON `null`) for any recording without markers.

This used to be handled: up through 3.12.1, `core.js` normalized markers through `Array.isArray` before assignment (`this.markers = this._normalizeMarkers(opts.markers)`), converting `null`/non-arrays to `undefined`. That guard was dropped at some point (not obviously intentional — no related changelog entry), so `develop` and all releases built from it inherit the crash.

## Fix

Restore the `Array.isArray` normalization at the point `opts.markers` is assigned, matching the pre-3.13 behavior. Minimal, localized change — `this.markers` has exactly one other read site (passed straight to the driver), so no other call site needed updating.

## Testing

Built `dist/bundle/asciinema-player.min.js` from this branch and loaded it in a real browser (Chromium via Playwright) against a local `.cast`:

- `create(src, container, { markers: null, ... })` — previously threw; now creates successfully, plays, no error overlay.
- `create(src, container, { markers: [[0.1, "start"], 0.2], ... })` — unaffected, works as before (regression check).

Found while self-hosting asciinema-server with a downstream fork ([deeplook/asciinema-player](https://github.com/deeplook/asciinema-player), adds inline OSC 1337 image rendering) — the fork inherited this same regression from `develop`, since it wasn't fork-specific.
